### PR TITLE
change local persistent store root folder to /run

### DIFF
--- a/cniplugin/pkg/portstore.go
+++ b/cniplugin/pkg/portstore.go
@@ -18,7 +18,7 @@ import (
 	"path"
 )
 
-const defaultStoreRootPath = "/etc/mizarmp_ports/"
+const defaultStoreRootPath = "/run/mizarmp/mizarmp_ports/"
 
 // PortIDStore keeps poirt id for sandbox/nic in persistent storage
 type PortIDStore struct {


### PR DESCRIPTION
current cni plugin puts local persistent store under /etc/mizarmp_ports/. Dynamic data like sandbox/port id allocations seems better under /run. This fixes #8, putting store root at /run/mizarmp/mizarmp_ports/. 